### PR TITLE
Fix segfault where method is called on uninitialised viewport

### DIFF
--- a/source/machine.d
+++ b/source/machine.d
@@ -139,15 +139,16 @@ class Machine
         }
         break;
       case SDL_TEXTINPUT:
-        this.focusedViewport.queueProgramStep(-1);
+        if (this.focusedViewport)
+          this.focusedViewport.queueProgramStep(-1);
         if (this.focusedViewport && this.focusedViewport.getTextinput())
           this.handleTextInput(this.focusedViewport.getTextinput(),
               to!string(cast(char*) event.text.text));
         break;
       case SDL_KEYDOWN:
-        this.focusedViewport.queueProgramStep(-1);
         if (this.focusedViewport)
         {
+          this.focusedViewport.queueProgramStep(-1);
           if ((SDL_GetModState() & KMOD_CTRL && event.key.keysym.sym < 128)
               || event.key.keysym.sym == 9 || event.key.keysym.sym == 27)
             this.focusedViewport.setHotkey(cast(char) event.key.keysym.sym);
@@ -190,7 +191,8 @@ class Machine
         }
         break;
       case SDL_KEYUP:
-        this.focusedViewport.queueProgramStep(-1);
+        if (this.focusedViewport)
+          this.focusedViewport.queueProgramStep(-1);
         break;
       default:
         // writeln("event ", event.type);


### PR DESCRIPTION
This pull request fixes an issue where if the user is typing before the view port has time to initialise it causes Homegirl to segfault.